### PR TITLE
chore: add npx skills support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ To upgrade:
 
 After installation, restart Claude Code. The skills will appear as `/evals-skills:<skill-name>`.
 
+## Installation (npx skills)
+
+If you use the open Skills CLI, install from this repo with:
+
+```bash
+npx skills add https://github.com/hamelsmu/evals-skills
+```
+
+Install one skill only:
+
+```bash
+npx skills add https://github.com/hamelsmu/evals-skills --skill eval-audit
+```
+
+Check for updates:
+
+```bash
+npx skills check
+npx skills update
+```
+
 ## Available Skills
 
 | Skill | What it does |

--- a/skills/build-review-interface/SKILL.md
+++ b/skills/build-review-interface/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: build-review-interface
 description: >
   Build a custom browser-based annotation interface tailored to your data for
   reviewing LLM traces and collecting structured feedback. Use when you need to

--- a/skills/error-analysis/SKILL.md
+++ b/skills/error-analysis/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: error-analysis
 description: >
   Help the user systematically identify and categorize failure modes in an LLM
   pipeline by reading traces. Use when starting a new eval project, after

--- a/skills/eval-audit/SKILL.md
+++ b/skills/eval-audit/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: eval-audit
 description: >
   Audit an LLM eval pipeline and surface problems: missing error analysis,
   unvalidated judges, vanity metrics, etc. Use when

--- a/skills/evaluate-rag/SKILL.md
+++ b/skills/evaluate-rag/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: evaluate-rag
 description: >
   Guides evaluation of RAG pipeline retrieval and generation quality.
   Use when evaluating a retrieval-augmented generation system, measuring retrieval quality,

--- a/skills/generate-synthetic-data/SKILL.md
+++ b/skills/generate-synthetic-data/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: generate-synthetic-data
 description: >
   Create diverse synthetic test inputs for LLM pipeline evaluation using
   dimension-based tuple generation. Use when bootstrapping an eval dataset,

--- a/skills/validate-evaluator/SKILL.md
+++ b/skills/validate-evaluator/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: validate-evaluator
 description: >
   Calibrate an LLM judge against human labels using data splits, TPR/TNR, and
   bias correction. Use after writing a judge prompt (write-judge-prompt) when you

--- a/skills/write-judge-prompt/SKILL.md
+++ b/skills/write-judge-prompt/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: write-judge-prompt
 description: >
   Design LLM-as-Judge evaluators for subjective criteria that code-based checks
   cannot handle. Use when a failure mode requires interpretation (tone,


### PR DESCRIPTION
Allows installation of the skills through the `skills` package as used by [https://skills.sh/](https://skills.sh/) so it can be used by Codex, Cursor and many other agents.