### PR TITLE
Add Cursor IDE plugin support

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "hamelsmu-evals-skills",
+  "owner": {
+    "name": "Hamel Husain"
+  },
+  "metadata": {
+    "description": "Skills for building LLM evaluations"
+  },
+  "plugins": [
+    {
+      "name": "evals-skills",
+      "source": "./",
+      "description": "Skills for building LLM evaluations: pipeline audit, error analysis, synthetic data generation, LLM-as-Judge design, evaluator validation, RAG evaluation, and annotation interfaces."
+    }
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "evals-skills",
+  "version": "0.2.0",
+  "description": "Skills for building LLM evaluations: pipeline audit, error analysis, synthetic data generation, LLM-as-Judge design, evaluator validation, RAG evaluation, and annotation interfaces.",
+  "author": {
+    "name": "Hamel Husain"
+  },
+  "homepage": "https://maven.com/parlance-labs/evals?promoCode=evals-info-url",
+  "repository": "https://github.com/hamelsmu/evals-skills",
+  "license": "MIT",
+  "keywords": ["evals", "llm", "evaluation", "rag", "judge", "annotation"]
+}

--- a/README.md
+++ b/README.md
@@ -24,14 +24,17 @@ The audit isn't a complete solution, but it will catch common problems we've see
 
 ### Cursor IDE
 
-Install the plugin from the Cursor Marketplace, or add it manually from GitHub:
+Run the install script from your terminal:
 
-1. Open Cursor Settings (`Cmd+Shift+J` on Mac, `Ctrl+Shift+J` on Windows/Linux)
-2. Navigate to **Rules**
-3. Click **Add Rule** and select **Remote Rule (GitHub)**
-4. Enter the repository URL: `https://github.com/hamelsmu/evals-skills`
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/hamelsmu/evals-skills/main/scripts/install-cursor.sh)
+```
 
-After installation, skills appear under **Agent Decides** in the Rules section. Invoke any skill by typing `/skill-name` in Agent chat (e.g., `/eval-audit`).
+This copies the plugin into `~/.cursor/plugins/evals-skills` and registers it so Cursor loads the skills on startup. Restart Cursor after running the script.
+
+After installation, the skills appear under **Skills** in Cursor Settings (`Cmd+Shift+J` on Mac, `Ctrl+Shift+J` on Windows/Linux) > **Rules, Skills, Subagents**. Invoke any skill by typing `/skill-name` in Agent chat (e.g., `/eval-audit`).
+
+To upgrade, re-run the install script.
 
 ### Claude Code
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,36 @@ Skills that guide AI coding agents to help you build LLM evaluations.
 
 These skills guard against common mistakes I've seen helping 50+ companies and teaching students in our [AI Evals course](https://maven.com/parlance-labs/evals?promoCode=evals-info-url). If you're new to evals, see [questions.md](questions.md) for free resources on the fundamentals.
 
+These skills follow the open [Agent Skills](https://agentskills.io/) standard and work in **Cursor**, **Claude Code**, and any agent that supports the standard.
+
 ## New to Evals? Start Here
 
-If you are new to evals, start with the `eval-audit` skill. Give your coding agent these instructions:
+If you are new to evals, start with the `eval-audit` skill. Install the plugin (see below), then give your coding agent these instructions:
 
-> Install the eval skills plugin from https://github.com/hamelsmu/evals-skills, then run /evals-skills:eval-audit on my eval pipeline. Investigate each diagnostic area using a separate subagent in parallel, then synthesize the findings into a single report. Use other skills in the plugin as recommended by the audit.
+**Cursor:**
+
+> Run /eval-audit on my eval pipeline. Investigate each diagnostic area using a separate subagent in parallel, then synthesize the findings into a single report. Use other skills in the plugin as recommended by the audit.
+
+**Claude Code:**
+
+> Run /evals-skills:eval-audit on my eval pipeline. Investigate each diagnostic area using a separate subagent in parallel, then synthesize the findings into a single report. Use other skills in the plugin as recommended by the audit.
 
 The audit isn't a complete solution, but it will catch common problems we've seen in evals. It will also recommend other skills to use to fix the problems.
 
 ## Installation
+
+### Cursor IDE
+
+Install the plugin from the Cursor Marketplace, or add it manually from GitHub:
+
+1. Open Cursor Settings (`Cmd+Shift+J` on Mac, `Ctrl+Shift+J` on Windows/Linux)
+2. Navigate to **Rules**
+3. Click **Add Rule** and select **Remote Rule (GitHub)**
+4. Enter the repository URL: `https://github.com/hamelsmu/evals-skills`
+
+After installation, skills appear under **Agent Decides** in the Rules section. Invoke any skill by typing `/skill-name` in Agent chat (e.g., `/eval-audit`).
+
+### Claude Code
 
 In Claude Code, run these two commands:
 
@@ -32,7 +53,7 @@ To upgrade:
 
 After installation, restart Claude Code. The skills will appear as `/evals-skills:<skill-name>`.
 
-## Installation (npx skills)
+### Skills CLI (npx skills)
 
 If you use the open Skills CLI, install from this repo with:
 
@@ -65,13 +86,21 @@ npx skills update
 | evaluate-rag | Evaluate retrieval and generation quality in RAG pipelines |
 | build-review-interface | Build custom annotation interfaces for human trace review |
 
-Invoke a skill with `/evals-skills:skill-name`, e.g., `/evals-skills:error-analysis`.
+### Usage by tool
+
+| Tool | Invoke a skill | Example |
+|------|---------------|--------|
+| Cursor | `/skill-name` or `@skill-name` | `/eval-audit` |
+| Claude Code | `/evals-skills:skill-name` | `/evals-skills:eval-audit` |
+| Skills CLI | Skill is loaded into agent context automatically | — |
+
+In Cursor, the agent also auto-applies relevant skills based on your conversation context.
 
 ## Write Your Own Skills
 
 These skills are a starting point and only encode common mistakes that generalize across projects. Skills grounded in your stack, your domain, and your data will outperform them. Start here, then write your own.
 
-The [meta-skill](meta-skill.md) can help you ground custom skills. 
+The [meta-skill](meta-skill.md) can help you ground custom skills.
 
 ## Beyond These Skills
 

--- a/scripts/install-cursor.sh
+++ b/scripts/install-cursor.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_NAME="evals-skills"
+PLUGIN_ID="${PLUGIN_NAME}@local"
+REPO_URL="https://github.com/hamelsmu/evals-skills"
+TARGET="$HOME/.cursor/plugins/$PLUGIN_NAME"
+CLAUDE_PLUGINS="$HOME/.claude/plugins/installed_plugins.json"
+CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+
+command -v git >/dev/null || { echo "Error: git is required." >&2; exit 1; }
+command -v python3 >/dev/null || { echo "Error: python3 is required." >&2; exit 1; }
+
+TMPDIR_CLONE="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_CLONE"' EXIT
+
+echo "Downloading $PLUGIN_NAME..."
+git clone --depth 1 --quiet "$REPO_URL" "$TMPDIR_CLONE"
+
+echo "Installing to $TARGET..."
+rm -rf "$TARGET"
+mkdir -p "$TARGET"
+for item in .cursor-plugin skills meta-skill.md; do
+  [ -e "$TMPDIR_CLONE/$item" ] && cp -R "$TMPDIR_CLONE/$item" "$TARGET/"
+done
+
+echo "Registering plugin..."
+mkdir -p "$HOME/.claude/plugins"
+
+python3 - "$CLAUDE_PLUGINS" "$PLUGIN_ID" "$TARGET" <<'PY'
+import json, os, sys
+path, pid, ipath = sys.argv[1], sys.argv[2], sys.argv[3]
+data = {}
+if os.path.exists(path):
+    try:
+        data = json.load(open(path))
+    except (json.JSONDecodeError, IOError):
+        data = {}
+plugins = data.get("plugins", {})
+entries = [e for e in plugins.get(pid, [])
+           if not (isinstance(e, dict) and e.get("scope") == "user")]
+entries.insert(0, {"scope": "user", "installPath": ipath})
+plugins[pid] = entries
+data["plugins"] = plugins
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+
+python3 - "$CLAUDE_SETTINGS" "$PLUGIN_ID" <<'PY'
+import json, os, sys
+path, pid = sys.argv[1], sys.argv[2]
+data = {}
+if os.path.exists(path):
+    try:
+        data = json.load(open(path))
+    except (json.JSONDecodeError, IOError):
+        data = {}
+data.setdefault("enabledPlugins", {})[pid] = True
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+
+echo ""
+echo "Installed $PLUGIN_NAME. Restart Cursor to load the skills."
+echo "Skills will appear in Settings > Rules, Skills, Subagents > Skills."


### PR DESCRIPTION
## Summary

Add native Cursor IDE support so the evals-skills plugin works in Cursor alongside the existing Claude Code and Skills CLI support.

- Add `.cursor-plugin/plugin.json` manifest conforming to Cursor's plugin schema
- Add `.cursor-plugin/marketplace.json` for marketplace/multi-plugin discovery
- Add `scripts/install-cursor.sh` one-liner install script for Cursor users
- Update README with Cursor installation instructions, usage table, and tool-agnostic quick-start prompts

No changes to existing skills, Claude Code support, or the Skills CLI workflow.

## What changed

| File | Change |
|------|--------|
| `.cursor-plugin/plugin.json` | New -- Cursor plugin manifest (mirrors `.claude-plugin/plugin.json` with Cursor-compatible schema) |
| `.cursor-plugin/marketplace.json` | New -- Cursor marketplace manifest (mirrors `.claude-plugin/marketplace.json`) |
| `scripts/install-cursor.sh` | New -- One-command install script that clones the repo, copies plugin files to `~/.cursor/plugins/`, and registers the plugin in `~/.claude/` config |
| `README.md` | Updated -- Added Cursor install section, usage-by-tool table, tool-agnostic intro |

## Why this works without touching skills

The skills (`skills/*/SKILL.md`) already follow the open [Agent Skills](https://agentskills.io/) standard. Cursor auto-discovers skills from the `skills/` directory when a `.cursor-plugin/plugin.json` manifest is present in the installed plugin directory. No skill modifications needed.

## How Cursor plugin installation works

Cursor loads locally-installed plugins via the `~/.claude/plugins/installed_plugins.json` registry and `~/.claude/settings.json` enable flags (Cursor shares Claude Code's config surface). The install script handles all three steps:

1. Clones the repo and copies `.cursor-plugin/` + `skills/` to `~/.cursor/plugins/evals-skills/`
2. Registers the plugin in `~/.claude/plugins/installed_plugins.json`
3. Enables the plugin in `~/.claude/settings.json`

Note: Simply having `.cursor-plugin/` in a workspace does NOT auto-install the plugin -- the plugin must be registered. This is why the install script is necessary.

## How to test

### In Cursor

1. Run the install script:
   ```bash
   bash <(curl -fsSL https://raw.githubusercontent.com/hamelsmu/evals-skills/cursor-support/scripts/install-cursor.sh)
   ```
   (Use `cursor-support` branch URL for testing; the README points to `main` for the final merged version)
2. Restart Cursor (full quit and reopen)
3. Open Settings (`Cmd+Shift+J`) > **Rules, Skills, Subagents**
4. Verify all 7 skills appear under **Skills**
5. Type `/eval-audit` in Agent chat -- confirm the skill loads
6. Type `@eval-audit` -- confirm it attaches as context

### In Claude Code (regression)

1. Install via `/plugin marketplace add hamelsmu/evals-skills` and `/plugin install evals-skills@hamelsmu-evals-skills`
2. Verify `/evals-skills:eval-audit` still works as before

### Via Skills CLI (regression)

1. `npx skills add https://github.com/hamelsmu/evals-skills`
2. Verify skills install correctly