### PR TITLE
Add Cursor IDE plugin support

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "hamelsmu-evals-skills",
+  "owner": {
+    "name": "Hamel Husain"
+  },
+  "metadata": {
+    "description": "Skills for building LLM evaluations"
+  },
+  "plugins": [
+    {
+      "name": "evals-skills",
+      "source": "./",
+      "description": "Skills for building LLM evaluations: pipeline audit, error analysis, synthetic data generation, LLM-as-Judge design, evaluator validation, RAG evaluation, and annotation interfaces."
+    }
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "evals-skills",
+  "version": "0.2.0",
+  "description": "Skills for building LLM evaluations: pipeline audit, error analysis, synthetic data generation, LLM-as-Judge design, evaluator validation, RAG evaluation, and annotation interfaces.",
+  "author": {
+    "name": "Hamel Husain"
+  },
+  "homepage": "https://maven.com/parlance-labs/evals?promoCode=evals-info-url",
+  "repository": "https://github.com/hamelsmu/evals-skills",
+  "license": "MIT",
+  "keywords": ["evals", "llm", "evaluation", "rag", "judge", "annotation"]
+}

--- a/README.md
+++ b/README.md
@@ -4,15 +4,35 @@ Skills that guide AI coding agents to help you build LLM evaluations.
 
 These skills guard against common mistakes I've seen helping 50+ companies and teaching students in our [AI Evals course](https://maven.com/parlance-labs/evals?promoCode=evals-info-url). If you're new to evals, see [questions.md](questions.md) for free resources on the fundamentals.
 
+These skills follow the open [Agent Skills](https://agentskills.io/) standard and work in **Cursor**, **Claude Code**, and any agent that supports the standard.
+
 ## New to Evals? Start Here
 
-If you are new to evals, start with the `eval-audit` skill. Give your coding agent these instructions:
+If you are new to evals, start with the `eval-audit` skill. Install the plugin (see below), then give your coding agent these instructions:
 
-> Install the eval skills plugin from https://github.com/hamelsmu/evals-skills, then run /evals-skills:eval-audit on my eval pipeline. Investigate each diagnostic area using a separate subagent in parallel, then synthesize the findings into a single report. Use other skills in the plugin as recommended by the audit.
+**Cursor:**
+
+> Run /eval-audit on my eval pipeline. Investigate each diagnostic area using a separate subagent in parallel, then synthesize the findings into a single report. Use other skills in the plugin as recommended by the audit.
+
+**Claude Code:**
+
+> Run /evals-skills:eval-audit on my eval pipeline. Investigate each diagnostic area using a separate subagent in parallel, then synthesize the findings into a single report. Use other skills in the plugin as recommended by the audit.
 
 The audit isn't a complete solution, but it will catch common problems we've seen in evals. It will also recommend other skills to use to fix the problems.
 
 ## Installation
+
+### Cursor IDE
+
+Install all skills with the Skills CLI:
+
+```bash
+npx skills add https://github.com/hamelsmu/evals-skills
+```
+
+After installation, the skills appear under **Skills** in Cursor Settings (`Cmd+Shift+J` on Mac, `Ctrl+Shift+J` on Windows/Linux) > **Rules, Skills, Subagents**. Invoke any skill by typing `/skill-name` in Agent chat (e.g., `/eval-audit`).
+
+### Claude Code
 
 In Claude Code, run these two commands:
 
@@ -32,7 +52,7 @@ To upgrade:
 
 After installation, restart Claude Code. The skills will appear as `/evals-skills:<skill-name>`.
 
-## Installation (npx skills)
+### Skills CLI (npx skills)
 
 If you use the open Skills CLI, install from this repo with:
 
@@ -65,7 +85,15 @@ npx skills update
 | evaluate-rag | Evaluate retrieval and generation quality in RAG pipelines |
 | build-review-interface | Build custom annotation interfaces for human trace review |
 
-Invoke a skill with `/evals-skills:skill-name`, e.g., `/evals-skills:error-analysis`.
+### Usage by tool
+
+| Tool | Invoke a skill | Example |
+|------|---------------|---------|
+| Cursor | `/skill-name` or `@skill-name` | `/eval-audit` |
+| Claude Code | `/evals-skills:skill-name` | `/evals-skills:eval-audit` |
+| Skills CLI | Skill is loaded into agent context automatically | — |
+
+In Cursor, the agent also auto-applies relevant skills based on your conversation context.
 
 ## Write Your Own Skills
 


### PR DESCRIPTION
## Summary

Add Cursor IDE support so the evals-skills plugin works in Cursor alongside Claude Code and the Skills CLI.

- Add `.cursor-plugin/plugin.json` and `.cursor-plugin/marketplace.json` for Cursor marketplace distribution
- Update README with Cursor installation/usage docs and a tool-agnostic intro

No changes to existing skills, Claude Code support, or the Skills CLI workflow.

## Changes

| File | Change |
|------|--------|
| `.cursor-plugin/plugin.json` | New — Cursor plugin manifest (mirrors `.claude-plugin/plugin.json`) |
| `.cursor-plugin/marketplace.json` | New — Cursor marketplace manifest (mirrors `.claude-plugin/marketplace.json`) |
| `README.md` | Updated — Cursor install section, usage-by-tool table, Agent Skills standard mention |

## Why no skill changes

The skills already follow the open [Agent Skills](https://agentskills.io/) standard (`SKILL.md` with `name`/`description` frontmatter). Cursor auto-discovers `skills/*/SKILL.md` from the plugin's `skills/` directory. No modifications needed.

## How to test

### Cursor

1. `npx skills add https://github.com/hamelsmu/evals-skills`
2. Restart Cursor
3. Settings > Rules, Skills, Subagents — verify 7 skills appear
4. Type `/eval-audit` in Agent chat — confirm skill loads

### Claude Code (regression)

1. `/plugin marketplace add hamelsmu/evals-skills` then `/plugin install evals-skills@hamelsmu-evals-skills`
2. Verify `/evals-skills:eval-audit` works as before

### Skills CLI (regression)

1. `npx skills add https://github.com/hamelsmu/evals-skills`
2. Verify skills install correctly