### PR TITLE
Add Codex skill discovery support

### DIFF
--- a/.agents/skills/build-review-interface
+++ b/.agents/skills/build-review-interface
@@ -1,0 +1,1 @@
+../../skills/build-review-interface

--- a/.agents/skills/error-analysis
+++ b/.agents/skills/error-analysis
@@ -1,0 +1,1 @@
+../../skills/error-analysis

--- a/.agents/skills/eval-audit
+++ b/.agents/skills/eval-audit
@@ -1,0 +1,1 @@
+../../skills/eval-audit

--- a/.agents/skills/evaluate-rag
+++ b/.agents/skills/evaluate-rag
@@ -1,0 +1,1 @@
+../../skills/evaluate-rag

--- a/.agents/skills/generate-synthetic-data
+++ b/.agents/skills/generate-synthetic-data
@@ -1,0 +1,1 @@
+../../skills/generate-synthetic-data

--- a/.agents/skills/validate-evaluator
+++ b/.agents/skills/validate-evaluator
@@ -1,0 +1,1 @@
+../../skills/validate-evaluator

--- a/.agents/skills/write-judge-prompt
+++ b/.agents/skills/write-judge-prompt
@@ -1,0 +1,1 @@
+../../skills/write-judge-prompt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Instructions
+
+This repository is a catalog of agent skills for LLM evaluation work.
+
+- Canonical skill content lives in `skills/*/SKILL.md`.
+- `.agents/skills/*` exists for Codex discovery and should stay as symlinks to the canonical skill folders.
+- When a skill's behavior or recommended invocation changes, update `README.md` in the same change.
+- Validate Codex support from the repo root with `codex --ask-for-approval never "Summarize the current instructions."`, `/skills`, and at least one explicit `$skill-name` invocation.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ If you are new to evals, start with the `eval-audit` skill. Give your coding age
 
 > Install the eval skills plugin from https://github.com/hamelsmu/evals-skills, then run /evals-skills:eval-audit on my eval pipeline. Investigate each diagnostic area using a separate subagent in parallel, then synthesize the findings into a single report. Use other skills in the plugin as recommended by the audit.
 
+> In Codex, open this repository and use `$eval-audit` on my eval pipeline. Investigate each diagnostic area using a separate subagent in parallel, then synthesize the findings into a single report. Use other skills from this repository as recommended by the audit.
+
 The audit isn't a complete solution, but it will catch common problems we've seen in evals. It will also recommend other skills to use to fix the problems.
 
 ## Installation
@@ -53,6 +55,27 @@ npx skills check
 npx skills update
 ```
 
+## Installation (Codex)
+
+Codex discovers repository skills from `.agents/skills` and personal skills from `~/.codex/skills`.
+
+Use these skills directly from a clone of this repository:
+
+```bash
+git clone https://github.com/hamelsmu/evals-skills.git
+cd evals-skills
+codex
+```
+
+From the Codex session, run `/skills` to confirm the skills are in scope, or invoke one explicitly with `$skill-name`, for example `$eval-audit`.
+
+To make one skill available in every Codex session, symlink or copy it into `~/.codex/skills`:
+
+```bash
+mkdir -p ~/.codex/skills
+ln -s /path/to/evals-skills/.agents/skills/eval-audit ~/.codex/skills/eval-audit
+```
+
 ## Available Skills
 
 | Skill | What it does |
@@ -65,7 +88,8 @@ npx skills update
 | evaluate-rag | Evaluate retrieval and generation quality in RAG pipelines |
 | build-review-interface | Build custom annotation interfaces for human trace review |
 
-Invoke a skill with `/evals-skills:skill-name`, e.g., `/evals-skills:error-analysis`.
+Invoke a skill in Claude Code with `/evals-skills:skill-name`, e.g., `/evals-skills:error-analysis`.
+In Codex, run `/skills` or invoke a skill explicitly with `$skill-name`, e.g., `$error-analysis`.
 
 ## Write Your Own Skills
 


### PR DESCRIPTION
## Summary
- add `.agents/skills` symlinks so Codex can discover the existing repo skills without duplicating content
- add a small root `AGENTS.md` with repo-specific Codex guidance
- document Codex usage alongside the existing Claude Code and `npx skills` flows in the README

## Validation
- ran `codex exec "Summarize the current instructions."` from the repo root and confirmed Codex loaded the new `AGENTS.md`
- ran `codex exec "What skills are available in this repository? List them by name only."` and confirmed Codex discovered the repo skills through `.agents/skills`
- ran `codex exec 'Use $eval-audit and tell me what artifacts it expects before auditing an eval pipeline.'` and confirmed explicit skill invocation works against the repo checkout

## Notes
- keeps `skills/*` as the canonical source of truth
- uses symlinks because Codex supports symlinked skill folders in `.agents/skills`
- avoids scripts and larger repo restructuring