### PR TITLE
Add deprecation notice pointing to the evals plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Eval Skills for AI Coding Agents
 
+> [!IMPORTANT]
+> This repository is deprecated. The skills moved to [ai-evals-course/error-discovery-skill](https://github.com/ai-evals-course/error-discovery-skill), a plugin called `evals` that Shreya Shankar and Hamel Husain maintain together. Install it with:
+>
+> ```bash
+> npx skills add https://github.com/ai-evals-course/error-discovery-skill
+> ```
+
 Skills that guide AI coding agents to help you build LLM evaluations.
 
 These skills guard against common mistakes I've seen helping 50+ companies and teaching students in our [AI Evals course](https://maven.com/parlance-labs/evals?promoCode=evals-info-url). If you're new to evals, see [questions.md](questions.md) for free resources on the fundamentals.


### PR DESCRIPTION
These skills moved to [ai-evals-course/error-discovery-skill](https://github.com/ai-evals-course/error-discovery-skill), a plugin called `evals` that Shreya Shankar and Hamel maintain together.

This adds a notice at the top of the README with the new repo and the one-line install command. Nothing else changes. After this merges, the repo can be archived on GitHub to finish the cutover.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code, config, or runtime behavior impact.
> 
> **Overview**
> Adds a GitHub **IMPORTANT** callout at the top of `README.md` stating this repo is deprecated and that the skills now live in **`ai-evals-course/error-discovery-skill`** as the **`evals`** plugin, with a one-line install: `npx skills add https://github.com/ai-evals-course/error-discovery-skill`.
> 
> No other files or README sections are updated in this PR; existing install instructions below the notice still reference this repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949a641bd59719092c86308702c3f19f2828e504. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->